### PR TITLE
Fix dependency versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,8 +11,8 @@ setup(
     license='MIT',
     packages=['barcode_reader'],
     install_requires=[
-        'numpy',
-        'opencv-python'
+        'numpy==1.17.3',
+        'opencv-python==3.4.7.28'
     ],
     zip_safe=False
 )


### PR DESCRIPTION
Fix OpenCV version to 3 in order to avoid API incompatibilities with version 4.